### PR TITLE
Wall add fix

### DIFF
--- a/src/01-search.ts
+++ b/src/01-search.ts
@@ -23,8 +23,8 @@ namespace search {
         dDir == Axis.X ? x = 1 : dDir == Axis.Y ? y = 1 : z = 1;
 
         // nBlockID is found at first Y position
-        if (blocks.testForBlock(nBlockID, positions.add(pPos, pos(x, y, z)))) {
-            return pPos.getValue(dDir);
+        if (blocks.testForBlock(nBlockID, pPos)) {
+            return 0;
         } 
 
         // Find range for binary search by repeated doubling

--- a/src/05-shapes.ts
+++ b/src/05-shapes.ts
@@ -571,13 +571,13 @@ namespace shapes {
             return 0;
         }
 
+        // Remove the mark if shown, otherwise the search below won't give proper results.
+        if (blocks.testForBlock(Data.nMarkBlock, pStart)) {
+            blocks.place(AIR, pStart);
+        }
+
         // use exponentional search to find the first AIR block in Y-direction.
         pCurWallHeight = pos(0, search.exponential(pStart, nMaxWallHeight, AIR), 0);
-        
-        // if there is no wall yet, set pCurWallHeight to 0
-        if (pCurWallHeight.getValue(Axis.Y) == nStartY) {
-            pCurWallHeight = pos(0,0,0);
-        }
 
         // Current wall Y-value.
         nCurY = pCurWallHeight.getValue(Axis.Y);


### PR DESCRIPTION
Two area where this bug got introduced. 

First, when a position is marked it has magenta carpet as mark block. When checking the current wall height with `search.exponential` it detects this block as the first block, so the function gives back there is already a wall at that position. So first check there is a carpet block, then remove it, before calling the `search.exponential` function.

Secondly, the `search.exponential` function returned the current positions Y-value when it detected there was no wall. So for example when you wanted to create a wall from Y = 4, it detects there is no wall and returned 4, instead of 0. So changed the return value to 0 instead of `pPos.getValue(dDir)`.